### PR TITLE
Added required peekonly to peek requests and removed get params

### DIFF
--- a/Basic.Azure.Storage.Tests.Integration/QueueServiceClientTests.cs
+++ b/Basic.Azure.Storage.Tests.Integration/QueueServiceClientTests.cs
@@ -1054,37 +1054,20 @@ namespace Basic.Azure.Storage.Tests.Integration
         }
 
         [Test]
-        public void PeekMessages_RequestItemWithVisibility_ReturnsItemWithFutureVisibility()
+        public void PeekMessages_RequestItem_DoesNotDequeueTheItem()
         {
             IQueueServiceClient client = new QueueServiceClient(_accountSettings);
             var queueName = GenerateSampleQueueName();
             CreateQueue(queueName);
             AddItemsToQueue(queueName, new List<string>() { "1" });
 
-            var response = client.PeekMessages(queueName, 1, 30);
+            var peekResponse = client.PeekMessages(queueName, 1);
+            Assert.AreEqual(1, peekResponse.Messages.Count);
 
-            Assert.AreEqual(1, response.Messages.Count);
-            var message = response.Messages.Single();
-            Assert.Less(message.InsertionTime, DateTime.UtcNow);
-            Assert.Greater(message.ExpirationTime, DateTime.UtcNow);
-            Assert.Greater(message.TimeNextVisible, DateTime.UtcNow);
+            var getResponse = client.GetMessages(queueName, 1);
+            Assert.AreEqual(1, getResponse.Messages.Count);
         }
 
-        [Test]
-        public void PeekMessages_RequestItemFromPopulatedQueue_ReturnsItemWithPopReceiptAndDequeueCount()
-        {
-            IQueueServiceClient client = new QueueServiceClient(_accountSettings);
-            var queueName = GenerateSampleQueueName();
-            CreateQueue(queueName);
-            AddItemsToQueue(queueName, new List<string>() { "1" });
-
-            var response = client.PeekMessages(queueName, 1, 30);
-
-            Assert.AreEqual(1, response.Messages.Count);
-            var message = response.Messages.Single();
-            Assert.IsNotNullOrEmpty(message.PopReceipt);
-            Assert.Greater(message.DequeueCount, 0);
-        }
         [Test]
         public async Task PeekMessagesAsync_EmptyQueue_ReturnsEmptyCollection()
         {

--- a/Basic.Azure.Storage/ClientContracts/IQueueServiceClient.cs
+++ b/Basic.Azure.Storage/ClientContracts/IQueueServiceClient.cs
@@ -55,8 +55,8 @@ namespace Basic.Azure.Storage.ClientContracts
         GetMessagesResponse GetMessages(string queueName, int numofMessages = 1, int visibilityTimeout = 30, int? messageTtl = null);
         Task<GetMessagesResponse> GetMessagesAsync(string queueName, int numofMessages = 1, int visibilityTimeout = 30, int? messageTtl = null);
 
-        PeekMessagesResponse PeekMessages(string queueName, int numofMessages = 1, int visibilityTimeout = 30, int? messageTtl = null);
-        Task<PeekMessagesResponse> PeekMessagesAsync(string queueName, int numofMessages = 1, int visibilityTimeout = 30, int? messageTtl = null);
+        PeekMessagesResponse PeekMessages(string queueName, int numofMessages = 1, int? messageTtl = null);
+        Task<PeekMessagesResponse> PeekMessagesAsync(string queueName, int numofMessages = 1, int? messageTtl = null);
 
         void DeleteMessage(string queueName, string messageId, string popReceipt);
         Task DeleteMessageAsync(string queueName, string messageId, string popReceipt);

--- a/Basic.Azure.Storage/Communications/QueueService/MessageOperations/PeekMessagesRequest.cs
+++ b/Basic.Azure.Storage/Communications/QueueService/MessageOperations/PeekMessagesRequest.cs
@@ -16,19 +16,16 @@ namespace Basic.Azure.Storage.Communications.QueueService.MessageOperations
     {
         private string _queueName;
         private int _numOfMessages;
-        private int _visibilityTimeout;
         private int? _messageTtl;
 
-        public PeekMessagesRequest(StorageAccountSettings settings, string queueName, int numOfMessages = 1, int visibilityTimeout = 30, int? messageTtl = null)
+        public PeekMessagesRequest(StorageAccountSettings settings, string queueName, int numOfMessages = 1, int? messageTtl = null)
             : base(settings)
         {
             //TODO: add Guard statements against invalid values, short circuit so we don't have the latency roundtrip to the server
-            //TODO: add Guard statements for visibilityTimeout
-
+            
             _queueName = queueName;
             _numOfMessages = numOfMessages;
 
-            _visibilityTimeout = visibilityTimeout;
             _messageTtl = messageTtl;
         }
 
@@ -42,9 +39,9 @@ namespace Basic.Azure.Storage.Communications.QueueService.MessageOperations
             builder.AddSegment(_queueName);
             builder.AddSegment("messages");
 
-            builder.AddParameter(ProtocolConstants.QueryParameters.NumOfMessages, _numOfMessages.ToString());
+            builder.AddParameter("peekonly", true.ToString());
 
-            builder.AddParameter(ProtocolConstants.QueryParameters.VisibilityTimeout, _visibilityTimeout.ToString());
+            builder.AddParameter(ProtocolConstants.QueryParameters.NumOfMessages, _numOfMessages.ToString());
 
             if (_messageTtl.HasValue)
                 builder.AddParameter(ProtocolConstants.QueryParameters.MessageTTL, _messageTtl.Value.ToString());

--- a/Basic.Azure.Storage/QueueServiceClient.cs
+++ b/Basic.Azure.Storage/QueueServiceClient.cs
@@ -162,15 +162,15 @@ namespace Basic.Azure.Storage
             return response.Payload;
         }
 
-        public PeekMessagesResponse PeekMessages(string queueName, int numofMessages = 1, int visibilityTimeout = 30, int? messageTtl = null)
+        public PeekMessagesResponse PeekMessages(string queueName, int numofMessages = 1, int? messageTtl = null)
         {
-            var request = new PeekMessagesRequest(_account, queueName, numofMessages, visibilityTimeout, messageTtl);
+            var request = new PeekMessagesRequest(_account, queueName, numofMessages, messageTtl);
             var response = request.Execute();
             return response.Payload;
         }
-        public async Task<PeekMessagesResponse> PeekMessagesAsync(string queueName, int numofMessages = 1, int visibilityTimeout = 30, int? messageTtl = null)
+        public async Task<PeekMessagesResponse> PeekMessagesAsync(string queueName, int numofMessages = 1, int? messageTtl = null)
         {
-            var request = new PeekMessagesRequest(_account, queueName, numofMessages, visibilityTimeout, messageTtl);
+            var request = new PeekMessagesRequest(_account, queueName, numofMessages, messageTtl);
             var response = await request.ExecuteAsync();
             return response.Payload;
         }


### PR DESCRIPTION
* Added peekonly=true to the params of the peek request; if not there, this performs a get instead.
* Added test to verify.
* Removed visibilityTimeout from PeekMessage as that is not supported (https://msdn.microsoft.com/en-us/library/azure/dd179472.aspx)
* Removed PopReceipt and DequeueCount as they are not supported by Peek
* Updated tests
