### PR TITLE
Support Azure SDK connnection strings, integration tests use app.config

### DIFF
--- a/Basic.Azure.Storage.Tests.Integration/BaseBlobServiceTestFixture.cs
+++ b/Basic.Azure.Storage.Tests.Integration/BaseBlobServiceTestFixture.cs
@@ -11,15 +11,15 @@ using Basic.Azure.Storage.Communications.ServiceExceptions;
 using Basic.Azure.Storage.Communications.Utility;
 using Microsoft.WindowsAzure.Storage.Blob;
 using BlobType = Microsoft.WindowsAzure.Storage.Blob.BlobType;
+using System.Configuration;
 
 namespace Basic.Azure.Storage.Tests.Integration
 {
     [TestFixture]
     public class BaseBlobServiceClientTestFixture
     {
-
-        protected readonly StorageAccountSettings _accountSettings = new LocalEmulatorAccountSettings();
-        protected readonly CloudStorageAccount _storageAccount = CloudStorageAccount.Parse("UseDevelopmentStorage=true");
+        protected StorageAccountSettings _accountSettings = StorageAccountSettings.Parse(ConfigurationManager.AppSettings["AzureConnectionString"]);
+        protected CloudStorageAccount _storageAccount = CloudStorageAccount.Parse(ConfigurationManager.AppSettings["AzureConnectionString"]);
 
         protected readonly Dictionary<string, string> _containersToCleanUp = new Dictionary<string, string>();
 

--- a/Basic.Azure.Storage.Tests.Integration/Basic.Azure.Storage.Tests.Integration.csproj
+++ b/Basic.Azure.Storage.Tests.Integration/Basic.Azure.Storage.Tests.Integration.csproj
@@ -57,6 +57,7 @@
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Basic.Azure.Storage.Tests.Integration/QueueServiceClientTests.cs
+++ b/Basic.Azure.Storage.Tests.Integration/QueueServiceClientTests.cs
@@ -7,6 +7,7 @@ using Microsoft.WindowsAzure.Storage.Queue.Protocol;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -17,8 +18,8 @@ namespace Basic.Azure.Storage.Tests.Integration
     [TestFixture]
     public class QueueServiceClientTests
     {
-        private StorageAccountSettings _accountSettings = new LocalEmulatorAccountSettings();
-        private CloudStorageAccount _storageAccount = CloudStorageAccount.Parse("UseDevelopmentStorage=true");
+        private StorageAccountSettings _accountSettings = StorageAccountSettings.Parse(ConfigurationManager.AppSettings["AzureConnectionString"]);
+        private CloudStorageAccount _storageAccount = CloudStorageAccount.Parse(ConfigurationManager.AppSettings["AzureConnectionString"]);
 
         private List<string> _queuesToCleanUp = new List<string>();
 

--- a/Basic.Azure.Storage.Tests.Integration/TableServiceClientTests.cs
+++ b/Basic.Azure.Storage.Tests.Integration/TableServiceClientTests.cs
@@ -5,6 +5,7 @@ using Microsoft.WindowsAzure.Storage;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -15,10 +16,8 @@ namespace Basic.Azure.Storage.Tests.Integration
     [TestFixture]
     public class TableServiceClientTests
     {
-        private StorageAccountSettings _accountSettings = new LocalEmulatorAccountSettings();
-        //for debugging: "ipv4.fiddler"
-        private CloudStorageAccount _storageAccount = CloudStorageAccount.Parse("UseDevelopmentStorage=true");
-        //for debugging: "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://ipv4.fiddler"
+        private StorageAccountSettings _accountSettings = StorageAccountSettings.Parse(ConfigurationManager.AppSettings["AzureConnectionString"]);
+        private CloudStorageAccount _storageAccount = CloudStorageAccount.Parse(ConfigurationManager.AppSettings["AzureConnectionString"]);
 
         private List<string> _tablesToCleanup = new List<string>();
 

--- a/Basic.Azure.Storage.Tests.Integration/app.config
+++ b/Basic.Azure.Storage.Tests.Integration/app.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <!-- for debugging: "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://ipv4.fiddler" -->
+    <add key="AzureConnectionString" value="UseDevelopmentStorage=true;"/>
+  </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/Basic.Azure.Storage.Tests/Basic.Azure.Storage.Tests.csproj
+++ b/Basic.Azure.Storage.Tests/Basic.Azure.Storage.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Fakes\RequestWithEmptyPayload.cs" />
     <Compile Include="Fakes\SettingsFake.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StorageAccountSettingsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Basic.Azure.Storage\Basic.Azure.Storage.csproj">

--- a/Basic.Azure.Storage.Tests/StorageAccountSettingsTests.cs
+++ b/Basic.Azure.Storage.Tests/StorageAccountSettingsTests.cs
@@ -1,0 +1,175 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Basic.Azure.Storage.Tests
+{
+    [TestFixture]
+    public class StorageAccountSettingsTests
+    {
+
+        /* Connection String format: https://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
+         * 
+         * Development #1: UseDevelopmentStorage=true
+         * 
+         * Development #2: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;
+         * AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;
+         * BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
+         * TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;
+         * QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1; 
+         * 
+         * Development with proxy: UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://myProxyUri
+         * 
+         * Production Endpoints:
+         * AccountName=myAccountName;AccountKey=myAccountKey;
+         * 
+         * Optional Production Values:
+         * DefaultEndpointsProtocol=[http|https];
+         * EndpointSuffix=mySuffix;
+         * BlobEndpoint=myBlobEndpoint; 
+         * QueueEndpoint=myQueueEndpoint;
+         * TableEndpoint=myTableEndpoint;
+         * SharedAccessSignature=base64Signature (not supported)
+         * 
+         */
+
+        [Test]
+        public void Parse_UseDevelopmentStorage_ReturnsLocalEmulatorSettings()
+        {
+            string connectionString = "UseDevelopmentStorage=true";
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.IsInstanceOf<LocalEmulatorAccountSettings>(result);
+        }
+
+        [Test]
+        public void Parse_UseDevelopmentStorageWithproxy_SettingsIncludeProxy()
+        {
+            string connectionString = "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://PROXY-HERE";
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.AreEqual("http://PROXY-HERE:10000/devstoreaccount1", result.BlobEndpoint);
+            Assert.AreEqual("http://PROXY-HERE:10001/devstoreaccount1", result.QueueEndpoint);
+            Assert.AreEqual("http://PROXY-HERE:10002/devstoreaccount1", result.TableEndpoint);
+        }
+
+        [Test]
+        public void Parse_UseDevelopmentCredentials_ReturnsLocalEmulatorSettings()
+        {
+            string connectionString = "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.IsInstanceOf<LocalEmulatorAccountSettings>(result);
+        }
+
+
+        [Test]
+        public void Parse_UseNonDevelopmentCredentials_ReturnsNormalSettings()
+        {
+            string connectionString = "AccountName=some-account-name;AccountKey=some-account-key;";
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.IsInstanceOf<StorageAccountSettings>(result);
+            Assert.IsNotInstanceOf<LocalEmulatorAccountSettings>(result);
+        }
+
+        [Test]
+        public void Parse_NoProtocolSpecified_AssumesHttps()
+        {
+            string connectionString = "AccountName=some-account-name;AccountKey=some-account-key;";
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.IsTrue(result.BlobEndpoint.StartsWith("https://"), "BlobEndpoint should start with https");
+            Assert.IsTrue(result.QueueEndpoint.StartsWith("https://"), "QueueEndpoint should start with https");
+            Assert.IsTrue(result.TableEndpoint.StartsWith("https://"), "TableEndpoint should start with https");
+        }
+
+        [Test]
+        public void Parse_HttpsSpecified_UsesHttps()
+        {
+            string connectionString = "AccountName=some-account-name;AccountKey=some-account-key;";
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.IsTrue(result.BlobEndpoint.StartsWith("https://"), "BlobEndpoint should start with https");
+            Assert.IsTrue(result.QueueEndpoint.StartsWith("https://"), "QueueEndpoint should start with https");
+            Assert.IsTrue(result.TableEndpoint.StartsWith("https://"), "TableEndpoint should start with https");
+        }
+
+        [Test]
+        public void Parse_HttpSpecified_UsesHttp()
+        {
+            string connectionString = "DefaultEndpointsProtocol=http;AccountName=some-account-name;AccountKey=some-account-key;";
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.IsTrue(result.BlobEndpoint.StartsWith("http://"), "BlobEndpoint should start with https");
+            Assert.IsTrue(result.QueueEndpoint.StartsWith("http://"), "QueueEndpoint should start with https");
+            Assert.IsTrue(result.TableEndpoint.StartsWith("http://"), "TableEndpoint should start with https");
+        }
+
+        [Test]
+        public void Parse_BlobEndpointSpecified_OverridesDefaultValueForBlobStorage()
+        {
+            string expectedEndpoint = "http://expected.endpoint.here";
+            string connectionString = String.Format("AccountName=some-account-name;AccountKey=some-account-key;BlobEndpoint={0}", expectedEndpoint);
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            var defaultStorageSettings = new StorageAccountSettings("some-account-name", "", true);
+            Assert.AreEqual(expectedEndpoint, result.BlobEndpoint);
+            Assert.AreEqual(defaultStorageSettings.QueueEndpoint, result.QueueEndpoint);
+            Assert.AreEqual(defaultStorageSettings.TableEndpoint, result.TableEndpoint);
+        }
+
+        [Test]
+        public void Parse_QueueEndpointSpecified_OverridesDefaultValueForQueueStorage()
+        {
+            string expectedEndpoint = "http://expected.endpoint.here";
+            string connectionString = String.Format("AccountName=some-account-name;AccountKey=some-account-key;QueueEndpoint={0}", expectedEndpoint);
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            var defaultStorageSettings = new StorageAccountSettings("some-account-name", "", true);
+            Assert.AreEqual(defaultStorageSettings.BlobEndpoint, result.BlobEndpoint);
+            Assert.AreEqual(expectedEndpoint, result.QueueEndpoint);
+            Assert.AreEqual(defaultStorageSettings.TableEndpoint, result.TableEndpoint);
+        }
+
+        [Test]
+        public void Parse_TableEndpointSpecified_OverridesDefaultValueForTableStorage()
+        {
+            string expectedEndpoint = "http://expected.endpoint.here";
+            string connectionString = String.Format("AccountName=some-account-name;AccountKey=some-account-key;TableEndpoint={0}", expectedEndpoint);
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            var defaultStorageSettings = new StorageAccountSettings("some-account-name", "", true);
+            Assert.AreEqual(defaultStorageSettings.BlobEndpoint, result.BlobEndpoint);
+            Assert.AreEqual(defaultStorageSettings.QueueEndpoint, result.QueueEndpoint);
+            Assert.AreEqual(expectedEndpoint, result.TableEndpoint);
+        }
+
+
+        [Test]
+        public void Parse_EndointSuffixSupplied_UsesProvidedSuffixForAllAddresses()
+        {
+            string expectedSuffix = "core.expected.address";
+            string connectionString = String.Format("AccountName=some-account-name;AccountKey=some-account-key;EndpointSuffix={0}", expectedSuffix);
+
+            var result = StorageAccountSettings.Parse(connectionString);
+
+            Assert.IsTrue(result.BlobEndpoint.EndsWith(expectedSuffix), String.Format("Expected suffix of '{0} but actual value was {1}", expectedSuffix, result.BlobEndpoint));
+            Assert.IsTrue(result.QueueEndpoint.EndsWith(expectedSuffix), String.Format("Expected suffix of '{0} but actual value was {1}", expectedSuffix, result.QueueEndpoint));
+            Assert.IsTrue(result.TableEndpoint.EndsWith(expectedSuffix), String.Format("Expected suffix of '{0} but actual value was {1}", expectedSuffix, result.TableEndpoint));
+        }
+    }
+}

--- a/Basic.Azure.Storage/StorageAccountSettings.cs
+++ b/Basic.Azure.Storage/StorageAccountSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Basic.Azure.Storage.Communications.Utility;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -8,15 +9,32 @@ namespace Basic.Azure.Storage
 {
     public class StorageAccountSettings
     {
-        private const string ADDRESS_BASE_BLOB = "blob.core.windows.net";
-        private const string ADDRESS_BASE_QUEUE = "queue.core.windows.net";
-        private const string ADDRESS_BASE_TABLE = "table.core.windows.net";
+        private const string ADDRESS_BASE_BLOB = "blob";
+        private const string ADDRESS_BASE_QUEUE = "queue";
+        private const string ADDRESS_BASE_TABLE = "table";
+        private const string ADDRESS_DEFAULT_SUFFIX = "core.windows.net";
 
-        public StorageAccountSettings(string accountName, string accountKey, bool useHttps)
+        protected const string DEV_ACCOUNT_NAME = "devstoreaccount1";
+        protected const string DEV_ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        protected const string DEV_DEFAULT_URL = "127.0.0.1";
+
+
+        private readonly string _blobEndpoint;
+        private readonly string _queueEndpoint;
+        private readonly string _tableEndpoint;
+
+        public StorageAccountSettings(string accountName, string accountKey, bool useHttps = true,
+                                      string blobEndpoint = null, string queueEndpoint = null, string tableEndpoint = null,
+                                      string endpointSuffix = null)
         {
             AccountName = accountName;
             AccountKey = accountKey;
             UseHttps = useHttps;
+
+            var suffix = endpointSuffix ?? ADDRESS_DEFAULT_SUFFIX;
+            _blobEndpoint = blobEndpoint ?? GetEndpoint(ADDRESS_BASE_BLOB, suffix);
+            _queueEndpoint = queueEndpoint ?? GetEndpoint(ADDRESS_BASE_QUEUE, suffix);
+            _tableEndpoint = tableEndpoint ?? GetEndpoint(ADDRESS_BASE_TABLE, suffix);
         }
         public string AccountName { get; protected set; }
         public string AccountKey { get; protected set; }
@@ -24,16 +42,17 @@ namespace Basic.Azure.Storage
 
         public byte[] AccountKeyBytes { get { return Convert.FromBase64String(AccountKey); } }
 
-        public virtual string BlobEndpoint { get { return GetEndpoint(ADDRESS_BASE_BLOB); } }
-        public virtual string QueueEndpoint { get { return GetEndpoint(ADDRESS_BASE_QUEUE); } }
-        public virtual string TableEndpoint { get { return GetEndpoint(ADDRESS_BASE_TABLE); } }
-        
-        private string GetEndpoint(string serviceAddressBase)
+        public virtual string BlobEndpoint { get { return _blobEndpoint; } }
+        public virtual string QueueEndpoint { get { return _queueEndpoint; } }
+        public virtual string TableEndpoint { get { return _tableEndpoint; } }
+
+        private string GetEndpoint(string serviceAddressBase, string suffix)
         {
-            return String.Format("{0}://{1}.{2}", 
+            return String.Format("{0}://{1}.{2}.{3}",
                 UseHttps ? "https" : "http",
                 AccountName,
-                serviceAddressBase);
+                serviceAddressBase,
+                suffix);
         }
 
         /// <summary>
@@ -49,25 +68,71 @@ namespace Basic.Azure.Storage
             }
         }
 
+
+        public static StorageAccountSettings Parse(string connectionString)
+        {
+            var settings = connectionString.Split(';')
+                                           .Select(s => s.Split(new char[] { '=' }, 2))
+                                           .Where(s => s.Count() >= 1)
+                                           .ToDictionary(s => s[0], s => s.Count() == 2 ? s[1] : "");
+
+            if (IsDevelopmentStorage(settings))
+            {
+                string proxyUri = settings.ContainsKey("DevelopmentStorageProxyUri") ? settings["DevelopmentStorageProxyUri"] : null;
+                return new LocalEmulatorAccountSettings(proxyUri);
+            }
+
+            var accountName = settings.ContainsKey("AccountName") ? settings["AccountName"] : null;
+            var accountKey = settings.ContainsKey("AccountKey") ? settings["AccountKey"] : null;
+            // only use the less secure method if we got exactly what we're looking for
+            bool useHttp = settings.ContainsKey("DefaultEndpointsProtocol") && settings["DefaultEndpointsProtocol"].Equals("http", StringComparison.InvariantCultureIgnoreCase);
+
+            Guard.ArgumentIsNotNullOrEmpty("AccountName", accountName);
+            Guard.ArgumentIsNotNullOrEmpty("AccountKey", accountKey);
+
+
+            var blobEndpoint = settings.ContainsKey("BlobEndpoint") ? settings["BlobEndpoint"] : null;
+            var queueEndpoint = settings.ContainsKey("QueueEndpoint") ? settings["QueueEndpoint"] : null;
+            var tableEndpoint = settings.ContainsKey("TableEndpoint") ? settings["TableEndpoint"] : null;
+
+            var endpointSuffix = settings.ContainsKey("EndpointSuffix") ? settings["EndpointSuffix"] : null;
+
+            return new StorageAccountSettings(accountName, accountKey, !useHttp, blobEndpoint, queueEndpoint, tableEndpoint, endpointSuffix);
+        }
+
+        private static bool IsDevelopmentStorage(Dictionary<string, string> settings)
+        {
+            if (settings.ContainsKey("UseDevelopmentStorage"))
+            {
+                if (settings["UseDevelopmentStorage"].Equals("true", StringComparison.InvariantCultureIgnoreCase))
+                    return true;
+                else
+                    throw new ArgumentOutOfRangeException("UseDevelopmentStorage", "UseDevelopmentStorage should only be passed witha value of 'true' or not used at all.");
+            }
+            else if (settings.ContainsKey("AccountName") && settings["AccountName"].Equals(DEV_ACCOUNT_NAME, StringComparison.InvariantCultureIgnoreCase) &&
+                     settings.ContainsKey("AccountKey") && settings["AccountKey"].Equals(DEV_ACCOUNT_KEY, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
     }
 
     public class LocalEmulatorAccountSettings : StorageAccountSettings
     {
-        //protected const string DEV_DEFAULT_URL = "ipv4.fiddler";
-        protected const string DEV_DEFAULT_URL = "127.0.0.1";
-        protected const string DEV_ACCOUNT_NAME = "devstoreaccount1";
-        protected const string DEV_ACCOUNT_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
-
-        public LocalEmulatorAccountSettings(string proxyUri = DEV_DEFAULT_URL)
+        public LocalEmulatorAccountSettings(string proxyUri = null)
             : base(DEV_ACCOUNT_NAME, DEV_ACCOUNT_KEY, false)
         {
-            ProxyUri = proxyUri;
+            ProxyUri = proxyUri ?? String.Format("http://{0}", DEV_DEFAULT_URL);
         }
 
         public string ProxyUri { get; protected set; }
 
-        public override string BlobEndpoint { get { return String.Format("http://{0}:10000/devstoreaccount1", ProxyUri); } }
-        public override string QueueEndpoint { get { return String.Format("http://{0}:10001/devstoreaccount1", ProxyUri); } }
-        public override string TableEndpoint { get { return String.Format("http://{0}:10002/devstoreaccount1", ProxyUri); } }
+        public override string BlobEndpoint { get { return String.Format("{0}:10000/devstoreaccount1", ProxyUri); } }
+        public override string QueueEndpoint { get { return String.Format("{0}:10001/devstoreaccount1", ProxyUri); } }
+        public override string TableEndpoint { get { return String.Format("{0}:10002/devstoreaccount1", ProxyUri); } }
     }
 }


### PR DESCRIPTION
Support for parsing some of the azure SDK tokens matches the documentation, but may have edge cases I wasn't aware of since I had not used some of them (and the documentation is sparse).